### PR TITLE
Composer: require PHP >=8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "nette/neon": "^3.4.1"
   },
   "require-dev": {


### PR DESCRIPTION
Updates the PHP requirement in composer.json from >=8.1 to >=8.2.